### PR TITLE
Ambiguous IUPAC codes 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ dbgfm: main.o libdbgfm.a
 # Build bwtdisk-prepare
 
 bwtdisk-prepare: bwtdisk_prepare.o
-	$(CXX) $(INCLUDES) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS)
+	$(CXX) $(INCLUDES) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS) -L. -ldbgfm 
 
 # Tests
 

--- a/bwtdisk_prepare.cpp
+++ b/bwtdisk_prepare.cpp
@@ -12,6 +12,9 @@
 #include <fstream>
 #include <string>
 #include <stdlib.h>
+#include <time.h>
+
+#include "alphabet.h"
 
 int main(int argc, char** argv)
 {
@@ -31,6 +34,8 @@ int main(int argc, char** argv)
         exit(EXIT_FAILURE);
     }
 
+    srand(time(NULL));
+
     // Read the fasta file line by line.
     // When we hit a header we output a symbol separating the current record
     // from the last. Non-ACGT symbols in the records cause an error.
@@ -44,9 +49,19 @@ int main(int argc, char** argv)
             if(n_records++ > 0)
                 std::cout << '$';
         } else {
-            if(line.find_first_not_of("ACGT") != std::string::npos) {
-                fprintf(stderr, "Error: non-ACGT base found.\n");
-                exit(EXIT_FAILURE);
+            std::size_t pos = line.find_first_not_of("ACGT");
+            // loop while there are no more ambiguous bases found in line
+            while(pos != std::string::npos) {
+                if(!IUPAC::isValid(line[pos])) {
+                    fprintf(stderr, "Error: invalid IUPAC base found.\n");
+                    exit(EXIT_FAILURE);
+                }
+                std::string possibleSymbols = IUPAC::getPossibleSymbols(line[pos]);
+                // choose a random base from the possible symbols
+                char base = possibleSymbols[rand() % possibleSymbols.length()];
+                line[pos] = base;
+                // get the next ambiguous base
+                pos = line.find_first_not_of("ACGT");
             }
                
             std::cout << line;

--- a/bwtdisk_prepare.cpp
+++ b/bwtdisk_prepare.cpp
@@ -12,7 +12,6 @@
 #include <fstream>
 #include <string>
 #include <stdlib.h>
-#include <time.h>
 
 #include "alphabet.h"
 
@@ -34,8 +33,6 @@ int main(int argc, char** argv)
         exit(EXIT_FAILURE);
     }
 
-    srand(time(NULL));
-
     // Read the fasta file line by line.
     // When we hit a header we output a symbol separating the current record
     // from the last. Non-ACGT symbols in the records cause an error.
@@ -56,9 +53,8 @@ int main(int argc, char** argv)
                     fprintf(stderr, "Error: invalid IUPAC base found.\n");
                     exit(EXIT_FAILURE);
                 }
-                std::string possibleSymbols = IUPAC::getPossibleSymbols(line[pos]);
-                // choose a random base from the possible symbols
-                char base = possibleSymbols[rand() % possibleSymbols.length()];
+                // get the lexicographically smallest base for the code
+                char base = IUPAC::getPossibleSymbols(line[pos])[0];
                 line[pos] = base;
                 // get the next ambiguous base
                 pos = line.find_first_not_of("ACGT");

--- a/bwtdisk_prepare.cpp
+++ b/bwtdisk_prepare.cpp
@@ -54,8 +54,7 @@ int main(int argc, char** argv)
                     exit(EXIT_FAILURE);
                 }
                 // get the lexicographically smallest base for the code
-                char base = IUPAC::getPossibleSymbols(line[pos])[0];
-                line[pos] = base;
+                line[pos] = IUPAC::getPossibleSymbols(line[pos])[0];
                 // get the next ambiguous base
                 pos = line.find_first_not_of("ACGT");
             }


### PR DESCRIPTION
These changes adds functionality to accept ambiguous IUPAC codes in `bwtdisk_prepare`.

It handles the ambiguity by choosing a random base that is within the set of bases for that ambiguity code. For example, `N` can be `A`, `C`, `G`, or `T`;  `S` can be `C` or `G`; `H` can be `A`, `C`, or `T`; etc.

This required `libdbgfm` to be linked to `bwtdisk_prepare` because it uses the IUPAC methods found in `alphabet.cpp`.